### PR TITLE
Update enterpise repo to bookworm.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ nano /etc/apt/sources.list.d/pve-enterprise.list
 ```
 add '#' symbol before it
 ```
-#deb https://enterprise.proxmox.com stretch pve-enterprise
+#deb https://enterprise.proxmox.com/debian/pve bookworm pve-enterprise
 ```
 
 ## 2. Add free no-subscription repository


### PR DESCRIPTION
In Proxmox 8 we're working with bookworm (Debian 12) instead of stretch (Debian 9).

I've changed the commented repo from:
```
#deb https://enterprise.proxmox.com stretch pve-enterprise
```

to:
```
#deb https://enterprise.proxmox.com/debian/pve bookworm pve-enterprise
```

This should mitigate any confusion to users that see a different repo to the one in the guide.